### PR TITLE
Reorder no candidate options. Revert to default primary UI font.

### DIFF
--- a/prodigy/el_recipe.py
+++ b/prodigy/el_recipe.py
@@ -171,9 +171,9 @@ def _add_options(stream, kb, nlp, id_dict, kb_entities_url):
                 if candidates:
                     options=[]
                     # we add in a few additional options in case a correct ID can not be picked
-                    options.append({"id": "NEL_NoCandidate", "text": "No viable candidate."})
-                    options.append({"id": "NEL_MoreContext", "text": "Need more context to decide."})
                     options.append({"id": "NER_WrongType", "text": "Incorrect entity type returned by NER model."})
+                    options.append({"id": "NEL_MoreContext", "text": "Need more context to decide."})
+                    options.append({"id": "NEL_NoCandidate", "text": "No viable candidate."})
 
                     options.extend([
                         {"id": c.entity_, "html": _print_info(c.entity_, id_dict, matches[c.alias_], kb_entities_url)}

--- a/prodigy/prodigy.json
+++ b/prodigy/prodigy.json
@@ -19,11 +19,6 @@
       "mediumText": 24,
       "smallText": 20,
       "fontPrimary": [
-          "Lato",
-          "Helvetica",
-          "Roboto",
-          "Arial",
-          "sans-serif"
       ],
       "fontSecondary": [
           "Roboto Condensed",


### PR DESCRIPTION
## What does this change?

Pushing minor aesthetic changes to prodigy UI. 

1. Reordering the no kb candidate options to reflect the structure of the annotation guide.
2. Removing bespoke primary fonts on prodigy json file to revert to default font across both guardian paragraph and annotator options. 

## How to test?
Does the server still work as expected and are the changes visible in the UI?